### PR TITLE
Config operational improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ rand = "0.5"
 redis = { version = "0.10", optional = true }
 serde = { version = "1", optional = true }
 serde_json = { version = "~0.8", optional = true }
-toml = "0.2"
+toml = "0.5"
 
 [profile.release]
 opt-level = 3

--- a/src/flowgger/config.rs
+++ b/src/flowgger/config.rs
@@ -2,14 +2,44 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::io::{Error, ErrorKind};
 use std::path::Path;
-use toml;
+use toml::Value;
 
+/// [`Configuration`][] storage for flowgger configs
+/// This is a dumb storage, no validation is other that this is parsable toml is performed
+/// All validations must be implemented on the functionality module level
+///
+/// [`Configuration`]: https://github.com/jedisct1/flowgger/wiki/Configuration
 #[derive(Clone)]
 pub struct Config {
-    config: toml::Value,
+    config: Value,
 }
 
 impl Config {
+    /// Constructor for the Config object from a file source
+    /// Ingest path for toml configuration file in toml format and parse it using the
+    /// `Config::from_string` method
+    /// This does not make any validation on the content of the configuration file
+    ///
+    /// # Parameters
+    ///
+    /// - `path`: path to existing, readable and valid configuration file in toml format
+    ///
+    /// # Type parameters
+    ///
+    /// - `P`: is an implicit converion to [`std::path::Path`][https://doc.rust-lang.org/std/path/struct.Path.html]
+    ///
+    /// # Returns
+    ///
+    /// A `Result` which is:
+    ///
+    /// - `Ok`: Containing the Config object
+    /// - `Err`: if the file doesn't exist, is not readable, cannot be parsed into a string or is
+    /// not valid [`TOML`][https://github.com/toml-lang/toml#user-content-array]
+    ///
+    /// # Errors
+    ///
+    /// This function will return error if the file does not exists,is unreadbale, or is not valid
+    /// toml format
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Config, Error> {
         let mut fd = File::open(path)?;
         let mut toml = String::new();
@@ -17,8 +47,28 @@ impl Config {
         Config::from_string(&toml)
     }
 
+    /// Constructor for the Config object from a string
+    /// This does not make any validation on the content of the configuration file
+    ///
+    /// # Parameters
+    ///
+    /// - `toml`: str containing a valid toml confiration in string format
+    ///
+    /// # Returns
+    ///
+    /// A `Result` which is:
+    ///
+    /// - `Ok`: Containing the Config object
+    /// - `Err`: if the parameter string is is not valid [`TOML`][https://github.com/toml-lang/toml#user-content-array]
+    ///
+    ///
+    /// # Errors
+    ///
+    /// - `InvalidData: Syntax error - config file is not valid TOML`: will be returned if the toml
+    /// string is not valid toml and cannot be parsed
+    ///
     pub fn from_string(toml: &str) -> Result<Config, Error> {
-        let config = match toml.parse() {
+        let config: Value = match toml.parse() {
             Ok(config) => config,
             Err(_) => {
                 return Err(Error::new(
@@ -30,7 +80,102 @@ impl Config {
         Ok(Config { config })
     }
 
-    pub fn lookup<'a>(&'a self, path: &'a str) -> Option<&'a toml::Value> {
-        self.config.lookup(path)
+    /// Lookup a toml prefix from a string in dotted format
+    ///
+    /// # Paramters
+    /// - `path`: a dotted string like 'input.type`
+    ///
+    /// # Returns
+    /// Return an `Option` which is:
+    ///
+    /// - `Some`: Containing a toml::Value if the path pointed to an existing Value
+    /// - `None`: if the path is not associated to any Value in the configuration
+    pub fn lookup<'a>(&'a self, path: &'a str) -> Option<&'a Value> {
+        let path_parts: Vec<&str> = path.split('.').collect();
+        let mut current_value = &(self.config);
+        for index in path_parts.iter() {
+            if current_value.is_table() {
+                current_value = match current_value.get(index) {
+                    Some(value) => value,
+                    None => return None,
+                };
+            }
+        }
+        Some(&current_value)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_config_from_string() {
+        let section_name = "section";
+        let field_name = "field";
+        let field_value = "This is only a test";
+        let config = Config::from_string(
+            format!("[{}]\n{} = \"{}\"", section_name, field_name, field_value).as_str(),
+        )
+        .unwrap();
+        assert_eq!(
+            config.config[section_name][field_name].as_str().unwrap(),
+            field_value
+        );
+        assert_eq!(
+            config
+                .lookup(&[section_name, field_name].join("."))
+                .unwrap()
+                .as_str(),
+            Some(field_value)
+        );
+        assert!(config.lookup("non_existing_section").is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "Syntax error - config file is not valid TOML")]
+    fn test_config_from_string_bad() {
+        let _config = Config::from_string("[section]\n= \"no key\"").unwrap();
+    }
+
+    #[test]
+    fn test_config_from_path() {
+        let config = Config::from_path("tests/resources/good_config.toml").unwrap();
+        assert_eq!(
+            config
+                .lookup("this_is_a_valid_section.this_is_valid_field")
+                .unwrap()
+                .as_str(),
+            Some("this is a valid value")
+        );
+        assert_eq!(
+            config
+                .lookup("this_is_a_valid_section.with_a_valid_subsection.this_is_another_valid_field.dotted")
+                .unwrap()
+                .as_str(),
+            Some("with a valid value")
+        );
+        assert_eq!(
+            config
+                .lookup("this_is_a_valid_section.with_a_valid_subsection.integer_value")
+                .unwrap()
+                .as_integer(),
+            Some(42)
+        );
+        assert!(config.lookup("non_existing_section").is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "Syntax error - config file is not valid TOML")]
+    fn test_config_fromt_path_bad_format() {
+        let _config = Config::from_path("tests/resources/bad_config.toml").unwrap();
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Os { code: 2, kind: NotFound, message: \"No such file or directory\" }"
+    )]
+    fn test_config_fromt_path_no_file() {
+        let _config = Config::from_path("doesnotexist.toml").unwrap();
     }
 }

--- a/src/flowgger/config.rs
+++ b/src/flowgger/config.rs
@@ -167,7 +167,7 @@ mod test {
 
     #[test]
     #[should_panic(expected = "Syntax error - config file is not valid TOML")]
-    fn test_config_fromt_path_bad_format() {
+    fn test_config_from_path_bad_format() {
         let _config = Config::from_path("tests/resources/bad_config.toml").unwrap();
     }
 
@@ -175,7 +175,7 @@ mod test {
     #[should_panic(
         expected = "Os { code: 2, kind: NotFound, message: \"No such file or directory\" }"
     )]
-    fn test_config_fromt_path_no_file() {
+    fn test_config_from_path_no_file() {
         let _config = Config::from_path("doesnotexist.toml").unwrap();
     }
 }

--- a/src/flowgger/input/udp_input.rs
+++ b/src/flowgger/input/udp_input.rs
@@ -150,7 +150,6 @@ mod test {
     use crate::flowgger::get_encoder_rfc3164;
     use flate2::write::{GzEncoder, ZlibEncoder};
     use flate2::Compression;
-    use std::net;
     use std::sync::mpsc::{sync_channel, Receiver};
 
     const DEFAULT_QUEUE_SIZE: usize = 10_000_000;

--- a/src/flowgger/output/kafka_output.rs
+++ b/src/flowgger/output/kafka_output.rs
@@ -131,9 +131,8 @@ impl KafkaOutput {
         let brokers = config
             .lookup("output.kafka_brokers")
             .expect("output.kafka_brokers is required")
-            .as_slice()
-            .expect("Invalid list of Kafka brokers")
-            .to_vec();
+            .as_array()
+            .expect("Invalid list of Kafka brokers");
         let brokers = brokers
             .iter()
             .map(|x| {

--- a/src/flowgger/output/tls_output.rs
+++ b/src/flowgger/output/tls_output.rs
@@ -229,9 +229,8 @@ fn config_parse(config: &Config) -> (TlsConfig, u32) {
     let connect = config
         .lookup("output.connect")
         .expect("output.connect is required")
-        .as_slice()
-        .expect("output.connect must be a list")
-        .to_vec();
+        .as_array()
+        .expect("output.connect must be a list");
     let mut connect: Vec<String> = connect
         .iter()
         .map(|x| {

--- a/tests/resources/bad_config.toml
+++ b/tests/resources/bad_config.toml
@@ -1,0 +1,2 @@
+duplicate_field = "something"
+duplicate_field = "something else"

--- a/tests/resources/good_config.toml
+++ b/tests/resources/good_config.toml
@@ -1,0 +1,6 @@
+[this_is_a_valid_section]
+this_is_valid_field = "this is a valid value"
+
+[this_is_a_valid_section.with_a_valid_subsection]
+this_is_another_valid_field.dotted = "with a valid value"
+integer_value = 42


### PR DESCRIPTION
*Issue #13 #3 

Improving the state fo the config module

I've added tests for the functionality that it has, added docstring comments, and upgraded to the latest version of the toml library with the necessary change of interface.

Also I've noticed and error from my previous PR and removed an unused `use` from the udp_input tests module.

Kafka and tls modules needed to be updated as well as they were using an old method that doesn't exists anymore in toml 0.5, this actually reduced the amount of operations that we had to do as we were already needing a vector and not a slice


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
