### PR TITLE
Removing deprecated targets from the travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ matrix:
     - env: TARGET=x86_64-unknown-linux-gnu
     - env: TARGET=x86_64-unknown-linux-musl
     - env: TARGET=i686-unknown-linux-gnu DISABLE_TESTS=1
-    - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
-    - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
+    # - env: TARGET=i686-unknown-freebsd DISABLE_TESTS=1
+    # - env: TARGET=x86_64-unknown-freebsd DISABLE_TESTS=1
     - env: TARGET=aarch64-unknown-linux-gnu DISABLE_TESTS=1
     - env: TARGET=armv7-unknown-linux-gnueabihf DISABLE_TESTS=1
     - env: TARGET=mips-unknown-linux-gnu DISABLE_TESTS=1


### PR DESCRIPTION
* root cause: https://github.com/rust-embedded/cross/issues/306

Travis builds are failing after the latest update of https://github.com/rust-embedded/cross that deprecated 2 targets 

Removing the 2 targets

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
