### PR TITLE
Gelf and  Ltsv improvements and bug fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2018"
 name = "flowgger"
 version = "0.2.8"
-authors = ["Frank Denis <github@pureftpd.org>", "Matteo Bigoi <bigo@crisidev.org>", "Vivien Chene <viv.chene@gmail.com>"]
+authors = ["Frank Denis <github@pureftpd.org>", "Matteo Bigoi <bigo@crisidev.org>", "Vivien Chene <viv.chene@gmail.com>", "Francesco Berni <kurojishi@kurojishi.me>"]
 build = "build.rs"
 
 [[bin]]

--- a/src/flowgger/decoder/gelf_decoder.rs
+++ b/src/flowgger/decoder/gelf_decoder.rs
@@ -11,12 +11,25 @@ use serde_json::value::Value;
 pub struct GelfDecoder;
 
 impl GelfDecoder {
+    /// The GELF decoder doesn't support any configuration, the config is passed as an argument
+    /// just to respect the interface
     pub fn new(_config: &Config) -> GelfDecoder {
         GelfDecoder
     }
 }
 
 impl Decoder for GelfDecoder {
+    /// Implements decode from a GELF formated text line to a Record object
+    ///
+    /// # Parameters
+    /// - `line`: A string slice containing a JSON with valid GELF data
+    ///
+    /// # Returns
+    /// A `Result` that contain:
+    ///
+    /// - `Ok`: A record containing all the line parsed as a Record data struct
+    /// - `Err`: if there was any error parsing the line, that could be missing values, bad json or wrong
+    /// types associated with specific fields
     fn decode(&self, line: &str) -> Result<Record, &'static str> {
         let mut sd = StructuredData::new(None);
         let mut ts = None;
@@ -107,40 +120,81 @@ impl Decoder for GelfDecoder {
     }
 }
 
-#[test]
-fn test_gelf() {
-    let msg = r#"{"version":"1.1", "host": "example.org","short_message": "A short message that helps you identify what is going on", "full_message": "Backtrace here\n\nmore stuff", "timestamp": 1385053862.3072, "level": 1, "_user_id": 9001, "_some_info": "foo", "_some_env_var": "bar"}"#;
-    let res = GelfDecoder.decode(msg).unwrap();
-    assert!(res.ts == 1_385_053_862.307_2);
-    assert!(res.hostname == "example.org");
-    assert!(res.msg.unwrap() == "A short message that helps you identify what is going on");
-    assert!(res.full_msg.unwrap() == "Backtrace here\n\nmore stuff");
-    assert!(res.severity.unwrap() == 1);
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::flowgger::record::SEVERITY_MAX;
 
-    let sd = res.sd.unwrap();
-    let pairs = sd.pairs;
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::U64(v) = v {
-            k == "_user_id" && v == 9001
-        } else {
-            false
-        }));
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::String(v) = v {
-            k == "_some_info" && v == "foo"
-        } else {
-            false
-        }));
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::String(v) = v {
-            k == "_some_env_var" && v == "bar"
-        } else {
-            false
-        }));
+    #[test]
+    fn test_gelf_decoder() {
+        let msg = r#"{"version":"1.1", "host": "example.org","short_message": "A short message that helps you identify what is going on", "full_message": "Backtrace here\n\nmore stuff", "timestamp": 1385053862.3072, "level": 1, "_user_id": 9001, "_some_info": "foo", "_some_env_var": "bar"}"#;
+        let res = GelfDecoder.decode(msg).unwrap();
+        assert!(res.ts == 1_385_053_862.307_2);
+        assert!(res.hostname == "example.org");
+        assert!(res.msg.unwrap() == "A short message that helps you identify what is going on");
+        assert!(res.full_msg.unwrap() == "Backtrace here\n\nmore stuff");
+        assert!(res.severity.unwrap() == 1);
+
+        let sd = res.sd.unwrap();
+        let pairs = sd.pairs;
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::U64(v) = v {
+                k == "_user_id" && v == 9001
+            } else {
+                false
+            }));
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::String(v) = v {
+                k == "_some_info" && v == "foo"
+            } else {
+                false
+            }));
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::String(v) = v {
+                k == "_some_env_var" && v == "bar"
+            } else {
+                false
+            }));
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid value type in structured data")]
+    fn test_gelf_decoder_bad_key() {
+        let msg = r#"{"some_key": []}"#;
+        let _res = GelfDecoder.decode(&msg).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid GELF timestamp")]
+    fn test_gelf_decoder_bad_timestamp() {
+        let msg = r#"{"timestamp": "a string not a timestamp", "host": "anhostname"}"#;
+        let _res = GelfDecoder.decode(&msg).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid GELF input, unable to parse as a JSON object")]
+    fn test_gelf_decoder_invalid_input() {
+        let _res = GelfDecoder.decode("{some_key = \"some_value\"}").unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Unsupported GELF version")]
+    fn test_gelf_decoder_wrong_version() {
+        let msg = r#"{"version":"42"}"#;
+        let _res = GelfDecoder.decode(msg).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid severity level (too high)")]
+    fn test_gelf_decoder_severity_to_high() {
+        let _res = GelfDecoder
+            .decode(format!("{{\"level\": {}}}", SEVERITY_MAX + 1).as_str())
+            .unwrap();
+    }
 }

--- a/src/flowgger/decoder/ltsv_decoder.rs
+++ b/src/flowgger/decoder/ltsv_decoder.rs
@@ -246,204 +246,273 @@ fn parse_ts(line: &str) -> Result<f64, &'static str> {
         .or_else(|_| english_time_to_unix(line))
 }
 
-#[test]
-fn test_ltsv_suffixes() {
-    let config = Config::from_string(
-        "[input]\n[input.ltsv_schema]\ncounter = \"U64\"\nscore = \
-         \"I64\"\nmean = \"f64\"\ndone = \
-         \"bool\"\n[input.ltsv_suffixes]\nu64 = \"_u64\"\ni64 = \
-         \"_i64\"\nF64 = \"_f64\"\nBool = \"_bool\"\n",
-    );
-    let ltsv_decoder = LTSVDecoder::new(&config.unwrap());
-    let msg = "time:[10/Oct/2000:13:55:36 \
-               -0700]\tdone:true\tscore:-1\tmean:0.42\tcounter:42\tlevel:3\thost:\
-               testhostname\tname1:value1\tname 2: value 2\tn3:v3\tmessage:this is a test";
-    let res = ltsv_decoder.decode(msg).unwrap();
-    let sd = res.sd.unwrap();
-    let pairs = sd.pairs;
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::U64(v) = v {
-            k == "_counter_u64" && v == 42
-        } else {
-            false
-        }));
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::I64(v) = v {
-            k == "_score_i64" && v == -1
-        } else {
-            false
-        }));
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::F64(v) = v {
-            k == "_mean_f64" && f64::abs(v - 0.42) < 1e-5
-        } else {
-            false
-        }));
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::Bool(v) = v {
-            k == "_done_bool" && v
-        } else {
-            false
-        }));
-}
+#[cfg(test)]
+mod test {
 
-#[test]
-fn test_ltsv_suffixes_2() {
-    let config = Config::from_string(
-        "[input]\n[input.ltsv_schema]\ncounter_u64 = \
-         \"U64\"\nscore_i64 = \"I64\"\nmean_f64 = \
-         \"f64\"\ndone_bool = \"bool\"\n[input.ltsv_suffixes]\nu64 \
-         = \"_u64\"\ni64 = \"_i64\"\nf64 = \"_f64\"\nbool = \
-         \"_bool\"\n",
-    );
-    let ltsv_decoder = LTSVDecoder::new(&config.unwrap());
-    let msg = "time:[10/Oct/2000:13:55:36 \
-               -0700]\tdone_bool:true\tscore_i64:-1\tmean_f64:0.42\tcounter_u64:42\tlevel:3\thost:\
-               testhostname\tname1:value1\tname 2: value 2\tn3:v3\tmessage:this is a test";
-    let res = ltsv_decoder.decode(msg).unwrap();
-    let sd = res.sd.unwrap();
-    let pairs = sd.pairs;
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::U64(v) = v {
-            k == "_counter_u64" && v == 42
-        } else {
-            false
-        }));
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::I64(v) = v {
-            k == "_score_i64" && v == -1
-        } else {
-            false
-        }));
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::F64(v) = v {
-            k == "_mean_f64" && f64::abs(v - 0.42) < 1e-5
-        } else {
-            false
-        }));
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::Bool(v) = v {
-            k == "_done_bool" && v
-        } else {
-            false
-        }));
-}
+    use super::*;
 
-#[test]
-fn test_ltsv() {
-    let config = Config::from_string(
-        "[input]\n[input.ltsv_schema]\ncounter = \"u64\"\nscore = \
-         \"i64\"\nmean = \"f64\"\ndone = \"bool\"\n",
-    );
-    let ltsv_decoder = LTSVDecoder::new(&config.unwrap());
-    let msg = "time:1438790025.99\thost:testhostname\tname1:value1\tname 2: value \
-               2\tn3:v3";
-    let res = ltsv_decoder.decode(msg).unwrap();
-    assert!(res.ts == 1_438_790_025.99);
-}
+    #[test]
+    fn test_ltsv_decoder_suffixes() {
+        let config = Config::from_string(
+            "[input]\n[input.ltsv_schema]\ncounter = \"U64\"\nscore = \
+             \"I64\"\nmean = \"f64\"\ndone = \
+             \"bool\"\n[input.ltsv_suffixes]\nu64 = \"_u64\"\ni64 = \
+             \"_i64\"\nF64 = \"_f64\"\nBool = \"_bool\"\n",
+        );
+        let ltsv_decoder = LTSVDecoder::new(&config.unwrap());
+        let msg = "time:[10/Oct/2000:13:55:36 \
+                   -0700]\tdone:true\tscore:-1\tmean:0.42\tcounter:42\tlevel:3\thost:\
+                   testhostname\tname1:value1\tname 2: value 2\tn3:v3\tmessage:this is a test";
+        let res = ltsv_decoder.decode(msg).unwrap();
+        let sd = res.sd.unwrap();
+        let pairs = sd.pairs;
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::U64(v) = v {
+                k == "_counter_u64" && v == 42
+            } else {
+                false
+            }));
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::I64(v) = v {
+                k == "_score_i64" && v == -1
+            } else {
+                false
+            }));
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::F64(v) = v {
+                k == "_mean_f64" && f64::abs(v - 0.42) < 1e-5
+            } else {
+                false
+            }));
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::Bool(v) = v {
+                k == "_done_bool" && v
+            } else {
+                false
+            }));
+    }
 
-#[test]
-fn test_ltsv2() {
-    let config = Config::from_string(
-        "[input]\n[input.ltsv_schema]\ncounter = \"u64\"\nscore = \
-         \"i64\"\nmean = \"f64\"\ndone = \"bool\"\n",
-    );
-    let ltsv_decoder = LTSVDecoder::new(&config.unwrap());
-    let msg = "time:[2015-08-05T15:53:45.637824Z]\thost:testhostname\tname1:value1\tname 2: value \
-               2\tn3:v3";
-    let res = ltsv_decoder.decode(msg).unwrap();
-    println!("{}", res.ts);
-    assert!(res.ts == 1_438_790_025.637_824);
-}
+    #[test]
+    fn test_ltsv_decoder_suffixes_2() {
+        let config = Config::from_string(
+            "[input]\n[input.ltsv_schema]\ncounter_u64 = \
+             \"U64\"\nscore_i64 = \"I64\"\nmean_f64 = \
+             \"f64\"\ndone_bool = \"bool\"\n[input.ltsv_suffixes]\nu64 \
+             = \"_u64\"\ni64 = \"_i64\"\nf64 = \"_f64\"\nbool = \
+             \"_bool\"\n",
+        );
+        let ltsv_decoder = LTSVDecoder::new(&config.unwrap());
+        let msg =
+            "time:[10/Oct/2000:13:55:36 \
+             -0700]\tdone_bool:true\tscore_i64:-1\tmean_f64:0.42\tcounter_u64:42\tlevel:3\thost:\
+             testhostname\tname1:value1\tname 2: value 2\tn3:v3\tmessage:this is a test";
+        let res = ltsv_decoder.decode(msg).unwrap();
+        let sd = res.sd.unwrap();
+        let pairs = sd.pairs;
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::U64(v) = v {
+                k == "_counter_u64" && v == 42
+            } else {
+                false
+            }));
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::I64(v) = v {
+                k == "_score_i64" && v == -1
+            } else {
+                false
+            }));
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::F64(v) = v {
+                k == "_mean_f64" && f64::abs(v - 0.42) < 1e-5
+            } else {
+                false
+            }));
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::Bool(v) = v {
+                k == "_done_bool" && v
+            } else {
+                false
+            }));
+    }
 
-#[test]
-fn test_ltsv_3() {
-    let config = Config::from_string(
-        "[input]\n[input.ltsv_schema]\ncounter = \"u64\"\nscore = \
-         \"i64\"\nmean = \"f64\"\ndone = \"bool\"\n",
-    );
-    let ltsv_decoder = LTSVDecoder::new(&config.unwrap());
-    let msg = "time:[10/Oct/2000:13:55:36.3 \
-               -0700]\tdone:true\tscore:-1\tmean:0.42\tcounter:42\tlevel:3\thost:\
-               testhostname\tname1:value1\tname 2: value 2\tn3:v3\tmessage:this is a test";
-    let res = ltsv_decoder.decode(msg).unwrap();
-    assert!(res.ts == 971_211_336.3);
-    assert!(res.severity.unwrap() == 3);
+    #[test]
+    fn test_ltsv_decoder() {
+        let config = Config::from_string(
+            "[input]\n[input.ltsv_schema]\ncounter = \"u64\"\nscore = \
+             \"i64\"\nmean = \"f64\"\ndone = \"bool\"\n",
+        );
+        let ltsv_decoder = LTSVDecoder::new(&config.unwrap());
+        let msg = "time:1438790025.99\thost:testhostname\tname1:value1\tname 2: value \
+                   2\tn3:v3";
+        let res = ltsv_decoder.decode(msg).unwrap();
+        assert!(res.ts == 1_438_790_025.99);
+    }
 
-    assert!(res.hostname == "testhostname");
-    assert!(res.msg.unwrap() == "this is a test");
-    let sd = res.sd.unwrap();
-    let pairs = sd.pairs;
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::String(v) = v {
-            k == "_name1" && v == "value1"
-        } else {
-            false
-        }));
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::String(v) = v {
-            k == "_name 2" && v == " value 2"
-        } else {
-            false
-        }));
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::String(v) = v {
-            k == "_n3" && v == "v3"
-        } else {
-            false
-        }));
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::U64(v) = v {
-            k == "_counter" && v == 42
-        } else {
-            false
-        }));
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::I64(v) = v {
-            k == "_score" && v == -1
-        } else {
-            false
-        }));
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::F64(v) = v {
-            k == "_mean" && f64::abs(v - 0.42) < 1e-5
-        } else {
-            false
-        }));
-    assert!(pairs
-        .iter()
-        .cloned()
-        .any(|(k, v)| if let SDValue::Bool(v) = v {
-            k == "_done" && v == true
-        } else {
-            false
-        }));
+    #[test]
+    fn test_ltsv_decoder2() {
+        let config = Config::from_string(
+            "[input]\n[input.ltsv_schema]\ncounter = \"u64\"\nscore = \
+             \"i64\"\nmean = \"f64\"\ndone = \"bool\"\n",
+        );
+        let ltsv_decoder = LTSVDecoder::new(&config.unwrap());
+        let msg =
+            "time:[2015-08-05T15:53:45.637824Z]\thost:testhostname\tname1:value1\tname 2: value \
+             2\tn3:v3";
+        let res = ltsv_decoder.decode(msg).unwrap();
+        println!("{}", res.ts);
+        assert!(res.ts == 1_438_790_025.637_824);
+    }
+
+    #[test]
+    fn test_ltsv_decoder_3() {
+        let config = Config::from_string(
+            "[input]\n[input.ltsv_schema]\ncounter = \"u64\"\nscore = \
+             \"i64\"\nmean = \"f64\"\ndone = \"bool\"\n",
+        );
+        let ltsv_decoder = LTSVDecoder::new(&config.unwrap());
+        let msg = "time:[10/Oct/2000:13:55:36.3 \
+                   -0700]\tdone:true\tscore:-1\tmean:0.42\tcounter:42\tlevel:3\thost:\
+                   testhostname\tname1:value1\tname 2: value 2\tn3:v3\tmessage:this is a test";
+        let res = ltsv_decoder.decode(msg).unwrap();
+        assert!(res.ts == 971_211_336.3);
+        assert!(res.severity.unwrap() == 3);
+
+        assert!(res.hostname == "testhostname");
+        assert!(res.msg.unwrap() == "this is a test");
+        let sd = res.sd.unwrap();
+        let pairs = sd.pairs;
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::String(v) = v {
+                k == "_name1" && v == "value1"
+            } else {
+                false
+            }));
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::String(v) = v {
+                k == "_name 2" && v == " value 2"
+            } else {
+                false
+            }));
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::String(v) = v {
+                k == "_n3" && v == "v3"
+            } else {
+                false
+            }));
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::U64(v) = v {
+                k == "_counter" && v == 42
+            } else {
+                false
+            }));
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::I64(v) = v {
+                k == "_score" && v == -1
+            } else {
+                false
+            }));
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::F64(v) = v {
+                k == "_mean" && f64::abs(v - 0.42) < 1e-5
+            } else {
+                false
+            }));
+        assert!(pairs
+            .iter()
+            .cloned()
+            .any(|(k, v)| if let SDValue::Bool(v) = v {
+                k == "_done" && v == true
+            } else {
+                false
+            }));
+    }
+
+    #[test]
+    #[should_panic(expected = "Unable to parse the date")]
+    fn test_ltsv_decoder_bad_timestamp() {
+        let config = Config::from_string(
+            "[input]\n[input.ltsv_schema]\ncounter = \"u64\"\nscore = \
+             \"i64\"\nmean = \"f64\"\ndone = \"bool\"\n",
+        );
+        let ltsv_decoder = LTSVDecoder::new(&config.unwrap());
+        // msg has a bad timestamp (using number to indicate month instead of three letter format
+        let msg = "time:[10/8/2000:13:55:36.3 \
+                   -0700]\tdone:true\tscore:-1\tmean:0.42\tcounter:42\tlevel:3\thost:\
+                   testhostname\tname1:value1\tname 2: value 2\tn3:v3\tmessage:this is a test";
+        let _res = ltsv_decoder.decode(msg).unwrap();
+    }
+
+    #[test]
+    fn test_ltsv_decoder_bad_security_level() {
+        let config = Config::from_string(
+            "[input]\n[input.ltsv_schema]\ncounter = \"u64\"\nscore = \
+             \"i64\"\nmean = \"f64\"\ndone = \"bool\"\n",
+        );
+        let ltsv_decoder = LTSVDecoder::new(&config.unwrap());
+        let msg = "time:[10/Oct/2000:13:55:36.3 \
+                   -0700]\tdone:true\tscore:-1\tmean:0.42\tcounter:42\tlevel:8\thost:\
+                   testhostname\tname1:value1\tname 2: value 2\tn3:v3\tmessage:this is a test";
+        assert_eq!(
+            ltsv_decoder.decode(msg).unwrap_err(),
+            "Severity level should be <= 7"
+        );
+        let msg = "time:[10/Oct/2000:13:55:36.3 \
+                   -0700]\tdone:true\tscore:-1\tmean:0.42\tcounter:42\tlevel:-1\thost:\
+                   testhostname\tname1:value1\tname 2: value 2\tn3:v3\tmessage:this is a test";
+        assert_eq!(
+            ltsv_decoder.decode(msg).unwrap_err(),
+            "Invalid severity level"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Unsupported type in input.ltsv_schema for name [counter]")]
+    fn test_ltsv_decoder_bad_config_schema_name() {
+        let config = Config::from_string(
+            "[input]\n[input.ltsv_schema]\ncounter = \"apples\"\nscore = \
+             \"i64\"\nmean = \"f64\"\ndone = \"bool\"\n",
+        );
+        let _ltsv_decoder = LTSVDecoder::new(&config.unwrap());
+    }
+
+    #[test]
+    #[should_panic(expected = "Unsupported type in input.ltsv_suffixes for type [apples]")]
+    fn test_ltsv_decoder_bad_config_suffix_name() {
+        let config = Config::from_string(
+            "[input]\n[input.ltsv_schema]\ncounter_u64 = \
+             \"U64\"\nscore_i64 = \"I64\"\nmean_f64 = \
+             \"f64\"\ndone_bool = \"bool\"\n[input.ltsv_suffixes]\napples \
+             = \"_u64\"\ni64 = \"_i64\"\nf64 = \"_f64\"\nbool = \
+             \"_bool\"\n",
+        );
+        let _ltsv_decoder = LTSVDecoder::new(&config.unwrap());
+    }
 }

--- a/src/flowgger/encoder/gelf_encoder.rs
+++ b/src/flowgger/encoder/gelf_encoder.rs
@@ -185,4 +185,18 @@ mod tests {
             expected_msg
         );
     }
+
+    #[test]
+    #[should_panic(expected = "output.gelf_extra must be a list of key/value pairs")]
+    fn test_gelf_encoder_config_extra_should_be_section() {
+        let _encoder =
+            GelfEncoder::new(&Config::from_string("[output]\ngelf_extra = \"bar\"").unwrap());
+    }
+
+    #[test]
+    #[should_panic(expected = "output.gelf_extra values must be strings")]
+    fn test_gelf_encoder_config_extra_bad_type() {
+        let _encoder =
+            GelfEncoder::new(&Config::from_string("[output.gelf_extra]\n_some_info = 42").unwrap());
+    }
 }

--- a/src/flowgger/encoder/gelf_encoder.rs
+++ b/src/flowgger/encoder/gelf_encoder.rs
@@ -11,6 +11,19 @@ pub struct GelfEncoder {
 }
 
 impl GelfEncoder {
+    /// GELF Encoder constructor from parsing the output.gelf_extra section of the config
+    ///
+    /// # Parameters
+    ///
+    /// - `config`: a configuration file that can contain an output.gelf_extra section of elements,
+    /// or be empty. if the gelf_extra section is present it needs to contain a list of `key =
+    /// "value"` pairs that will be added to the resulting json or overwritten if already present
+    ///
+    /// # Panics
+    ///
+    /// All the possible failures are relative to parsing the configuration file
+    /// - `output.gelf_extra must be a list of key/value pairs`
+    /// - `output.gelf_extra values must be strings`
     pub fn new(config: &Config) -> GelfEncoder {
         let extra = match config.lookup("output.gelf_extra") {
             None => Vec::new(),
@@ -33,6 +46,13 @@ impl GelfEncoder {
 }
 
 impl Encoder for GelfEncoder {
+    /// Implements encode for GELF output types
+    ///
+    /// # Returns
+    /// A `Result` containing
+    ///
+    /// - `Ok` Containing a byte vector rapresenting a valid GELF JSON
+    /// - `Err` if the Record could not be serialized to a valid JSON
     fn encode(&self, record: Record) -> Result<Vec<u8>, &'static str> {
         let mut map = ObjectBuilder::new()
             .insert("version".to_owned(), Value::String("1.1".to_owned()))
@@ -61,9 +81,6 @@ impl Encoder for GelfEncoder {
         if let Some(procid) = record.procid {
             map = map.insert("process_id".to_owned(), Value::String(procid));
         }
-        for (name, value) in self.extra.iter().cloned() {
-            map = map.insert(name, Value::String(value));
-        }
         if let Some(sd) = record.sd {
             if let Some(sd_id) = sd.sd_id {
                 map = map.insert("sd_id".to_owned(), Value::String(sd_id));
@@ -80,7 +97,92 @@ impl Encoder for GelfEncoder {
                 map = map.insert(name, value);
             }
         }
+        for (name, value) in self.extra.iter().cloned() {
+            map = map.insert(name, Value::String(value));
+        }
         let json = serde_json::to_vec(&map.build()).or(Err("Unable to serialize to JSON"))?;
         Ok(json)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::flowgger::record::{SDValue, StructuredData};
+
+    #[test]
+    fn test_gelf_encode() {
+        let expected_msg = r#"{"_some_info":"foo","application_name":"appname","full_message":"Backtrace here\n\nmore stuff","host":"example.org","level":1,"process_id":"44","sd_id":"someid","secret-token":"secret","short_message":"A short message that helps you identify what is going on","timestamp":1385053862.3072,"version":"1.1"}"#;
+        let config = Config::from_string("[output.gelf_extra]\nsecret-token = \"secret\"").unwrap();
+        let sd = StructuredData {
+            sd_id: Some("someid".to_string()),
+            pairs: vec![("_some_info".to_string(), SDValue::String("foo".to_string()))],
+        };
+        let record = Record {
+            ts: 1385053862.3072,
+            hostname: "example.org".to_string(),
+            facility: None,
+            severity: Some(1),
+            appname: Some("appname".to_string()),
+            procid: Some("44".to_string()),
+            msgid: None,
+            msg: Some("A short message that helps you identify what is going on".to_string()),
+            full_msg: Some("Backtrace here\n\nmore stuff".to_string()),
+            sd: Some(sd),
+        };
+        let encoder = GelfEncoder::new(&config);
+        assert_eq!(
+            String::from_utf8_lossy(&encoder.encode(record).unwrap()),
+            expected_msg
+        );
+    }
+
+    #[test]
+    fn test_gelf_encode_empty_hostname() {
+        let expected_msg = r#"{"host":"unknown","level":1,"short_message":"A short message that helps you identify what is going on","timestamp":1385053862.3072,"version":"1.1"}"#;
+        let config = Config::from_string("").unwrap();
+        let record = Record {
+            ts: 1385053862.3072,
+            hostname: "".to_string(),
+            facility: None,
+            severity: Some(1),
+            appname: None,
+            procid: None,
+            msgid: None,
+            msg: Some("A short message that helps you identify what is going on".to_string()),
+            full_msg: None,
+            sd: None,
+        };
+        let encoder = GelfEncoder::new(&config);
+        assert_eq!(
+            String::from_utf8_lossy(&encoder.encode(record).unwrap()),
+            expected_msg
+        );
+    }
+
+    #[test]
+    fn test_gelf_encode_replace_extra() {
+        let expected_msg = r#"{"a_key":"bar","host":"unknown","level":1,"short_message":"A short message that helps you identify what is going on","timestamp":1385053862.3072,"version":"1.1"}"#;
+        let config = Config::from_string("[output.gelf_extra]\na_key = \"bar\"").unwrap();
+        let mut sd = StructuredData::new(None);
+        sd.pairs
+            .push(("a_key".to_string(), SDValue::String("foo".to_string())));
+        let record = Record {
+            ts: 1385053862.3072,
+            hostname: "".to_string(),
+            facility: None,
+            severity: Some(1),
+            appname: None,
+            procid: None,
+            msgid: None,
+            msg: Some("A short message that helps you identify what is going on".to_string()),
+            full_msg: None,
+            sd: Some(sd),
+        };
+        let encoder = GelfEncoder::new(&config);
+        assert_eq!(
+            String::from_utf8_lossy(&encoder.encode(record).unwrap()),
+            expected_msg
+        );
     }
 }


### PR DESCRIPTION
*Changes triggered by issue #13 
Working on this made me open #22 and #21 and this PR solves them

* Added more tests to GELF and LTSV decoder and used the ```mod test``` structure used in the rest of the code
* Added tests to GELF encoder, found a small bug where output.gelf_extras wasn't overriding values and fixes it
* Added tests to LTSV encoder and found a big bug where not only output.ltsv_extras where not being overriden, but where just get appended as the code was using a String as a data store
* Added docstrings to both modules
* Added myself between the authors of the package

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
